### PR TITLE
removing need for hadolint in building image

### DIFF
--- a/models/aether-2.0.x/Makefile
+++ b/models/aether-2.0.x/Makefile
@@ -59,7 +59,7 @@ hadolint: #lint the Dockerfile
 	    echo "hadolint downloaded to $$HOME/${LOCAL_BIN} - ensure this dir is in PATH")
 	hadolint Dockerfile
 
-image: hadolint mod-update # @HELP Build the docker image (available parameters: DOCKER_REPOSITORY, VERSION)
+image: mod-update # @HELP Build the docker image (available parameters: DOCKER_REPOSITORY, VERSION)
 	docker build --platform ${PLATFORM} $(DOCKER_BUILD_ARGS) -t ${DOCKER_REPOSITORY}aether-2.0.x:${VERSION} .
 	docker tag ${DOCKER_REPOSITORY}aether-2.0.x:${VERSION} ${DOCKER_REPOSITORY}aether-2.0.x:${LATEST_VERSION}
 

--- a/models/aether-2.1.x/Makefile
+++ b/models/aether-2.1.x/Makefile
@@ -59,7 +59,7 @@ hadolint: #lint the Dockerfile
 	    echo "hadolint downloaded to $$HOME/${LOCAL_BIN} - ensure this dir is in PATH")
 	hadolint Dockerfile
 
-image: hadolint mod-update # @HELP Build the docker image (available parameters: DOCKER_REPOSITORY, VERSION)
+image: mod-update # @HELP Build the docker image (available parameters: DOCKER_REPOSITORY, VERSION)
 	docker build --platform ${PLATFORM} $(DOCKER_BUILD_ARGS) -t ${DOCKER_REPOSITORY}aether-2.1.x:${VERSION} .
 	docker tag ${DOCKER_REPOSITORY}aether-2.1.x:${VERSION} ${DOCKER_REPOSITORY}aether-2.1.x:${LATEST_VERSION}
 


### PR DESCRIPTION
Removing this as Jenkins image does not have `hadolint` yet and hence publish fails